### PR TITLE
Migrate to RxJava 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RxWorkManagerObservers
+# An RxJava3 fork of [RxWorkManagerObservers](https://github.com/PaulinaSadowska/RxWorkManagerObservers)
 
 This library contains a set of extension functions to the WorkManager and LiveData allowing to observe enqueued work in a reactive manner.
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.21'
+    ext.kotlin_version = '1.5.31'
     repositories {
         google()
-        jcenter()
-
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:7.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -18,7 +17,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Mar 16 12:50:33 CET 2019
+#Tue Dec 14 18:53:07 EET 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,4 @@
+jdk:
+  - openjdk11
+install:
+  - ./gradlew build :rx-workmanager-observers:publishToMavenLocal

--- a/rx-workmanager-observers/build.gradle
+++ b/rx-workmanager-observers/build.gradle
@@ -2,13 +2,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 28
-
-
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -23,12 +21,15 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
 }
 
 ext {
     ext.versions = [:]
-    versions.androidX = "1.0.2"
-    versions.workManager = "2.0.0"
+    versions.androidX = "1.1.0"
+    versions.workManager = "2.5.0"
 
     versions.rxJava = "3.1.3"
     versions.rxAndroid = "3.0.0"
@@ -36,7 +37,7 @@ ext {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     implementation "androidx.appcompat:appcompat:$versions.androidX"
 

--- a/rx-workmanager-observers/build.gradle
+++ b/rx-workmanager-observers/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'maven-publish'
 
 android {
     compileSdkVersion 30
@@ -23,6 +24,16 @@ android {
     }
     kotlinOptions {
         jvmTarget = '1.8'
+    }
+}
+
+project.afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.release
+            }
+        }
     }
 }
 

--- a/rx-workmanager-observers/build.gradle
+++ b/rx-workmanager-observers/build.gradle
@@ -30,8 +30,8 @@ ext {
     versions.androidX = "1.0.2"
     versions.workManager = "2.0.0"
 
-    versions.rxJava = "2.2.7"
-    versions.rxAndroid = "2.1.1"
+    versions.rxJava = "3.1.3"
+    versions.rxAndroid = "3.0.0"
 }
 
 dependencies {
@@ -45,8 +45,8 @@ dependencies {
     androidTestImplementation "androidx.work:work-testing:$versions.workManager"
 
     // Rx
-    implementation "io.reactivex.rxjava2:rxjava:$versions.rxJava"
-    implementation "io.reactivex.rxjava2:rxandroid:$versions.rxAndroid"
+    implementation "io.reactivex.rxjava3:rxjava:$versions.rxJava"
+    implementation "io.reactivex.rxjava3:rxandroid:$versions.rxAndroid"
 
     // unit tests
     testImplementation 'junit:junit:4.12'

--- a/rx-workmanager-observers/src/androidTest/java/com/paulinasadowska/rxworkmanagerobservers/UniqueWorkDataTest.kt
+++ b/rx-workmanager-observers/src/androidTest/java/com/paulinasadowska/rxworkmanagerobservers/UniqueWorkDataTest.kt
@@ -8,7 +8,7 @@ import com.paulinasadowska.rxworkmanagerobservers.utils.DEFAULT_DELAY_LONG
 import com.paulinasadowska.rxworkmanagerobservers.utils.initializeTestWorkManager
 import com.paulinasadowska.rxworkmanagerobservers.workers.EchoWorker
 import com.paulinasadowska.rxworkmanagerobservers.workers.EchoWorker.Companion.KEY_ECHO_MESSAGE
-import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 import org.hamcrest.collection.IsIterableContainingInAnyOrder

--- a/rx-workmanager-observers/src/androidTest/java/com/paulinasadowska/rxworkmanagerobservers/UniqueWorkDataTest.kt
+++ b/rx-workmanager-observers/src/androidTest/java/com/paulinasadowska/rxworkmanagerobservers/UniqueWorkDataTest.kt
@@ -1,9 +1,9 @@
 package com.paulinasadowska.rxworkmanagerobservers
 
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.*
 import com.paulinasadowska.rxworkmanagerobservers.extensions.getWorkDatasForUniqueWorkObservable
-import com.paulinasadowska.rxworkmanagerobservers.utils.DEFAULT_DELAY
 import com.paulinasadowska.rxworkmanagerobservers.utils.DEFAULT_DELAY_LONG
 import com.paulinasadowska.rxworkmanagerobservers.utils.initializeTestWorkManager
 import com.paulinasadowska.rxworkmanagerobservers.workers.EchoWorker
@@ -29,7 +29,7 @@ class UniqueWorkDataTest {
         internal const val SMALL_DELAY = 10L
     }
 
-    private val workManager by lazy { WorkManager.getInstance() }
+    private val workManager by lazy { WorkManager.getInstance(getApplicationContext()) }
 
     @Before
     fun setUp() {

--- a/rx-workmanager-observers/src/androidTest/java/com/paulinasadowska/rxworkmanagerobservers/WorkDataSingleTest.kt
+++ b/rx-workmanager-observers/src/androidTest/java/com/paulinasadowska/rxworkmanagerobservers/WorkDataSingleTest.kt
@@ -15,7 +15,7 @@ import com.paulinasadowska.rxworkmanagerobservers.utils.initializeTestWorkManage
 import com.paulinasadowska.rxworkmanagerobservers.workers.EchoWorker
 import com.paulinasadowska.rxworkmanagerobservers.workers.EchoWorker.Companion.KEY_ECHO_MESSAGE
 import com.paulinasadowska.rxworkmanagerobservers.workers.EmptyWorker
-import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/rx-workmanager-observers/src/androidTest/java/com/paulinasadowska/rxworkmanagerobservers/WorkDataSingleTest.kt
+++ b/rx-workmanager-observers/src/androidTest/java/com/paulinasadowska/rxworkmanagerobservers/WorkDataSingleTest.kt
@@ -1,5 +1,6 @@
 package com.paulinasadowska.rxworkmanagerobservers
 
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.OneTimeWorkRequest
 import androidx.work.OneTimeWorkRequestBuilder
@@ -8,7 +9,6 @@ import androidx.work.testing.WorkManagerTestInitHelper
 import androidx.work.workDataOf
 import com.paulinasadowska.rxworkmanagerobservers.exceptions.WorkFailedException
 import com.paulinasadowska.rxworkmanagerobservers.extensions.getWorkDataByIdSingle
-import com.paulinasadowska.rxworkmanagerobservers.extensions.toWorkDataSingle
 import com.paulinasadowska.rxworkmanagerobservers.utils.DEFAULT_DELAY
 import com.paulinasadowska.rxworkmanagerobservers.utils.createEchoRequest
 import com.paulinasadowska.rxworkmanagerobservers.utils.initializeTestWorkManager
@@ -29,7 +29,7 @@ class WorkDataSingleTest {
         private const val EXAMPLE_ECHO_MESSAGE = "some message"
     }
 
-    private val workManager by lazy { WorkManager.getInstance() }
+    private val workManager by lazy { WorkManager.getInstance(getApplicationContext()) }
 
     @Before
     fun setUp() {
@@ -80,7 +80,7 @@ class WorkDataSingleTest {
                         .setInitialDelay(10, TimeUnit.DAYS)
                         .build()
 
-        val testDriver = WorkManagerTestInitHelper.getTestDriver()
+        val testDriver = WorkManagerTestInitHelper.getTestDriver(getApplicationContext())
 
         //when
         workManager.enqueue(request)
@@ -92,7 +92,7 @@ class WorkDataSingleTest {
         sleep(DEFAULT_DELAY)
 
         workSingle.assertNoValues()
-        testDriver.setInitialDelayMet(request.id)
+        testDriver?.setInitialDelayMet(request.id)
 
         sleep(DEFAULT_DELAY)
 

--- a/rx-workmanager-observers/src/androidTest/java/com/paulinasadowska/rxworkmanagerobservers/WorkDatasObservableTest.kt
+++ b/rx-workmanager-observers/src/androidTest/java/com/paulinasadowska/rxworkmanagerobservers/WorkDatasObservableTest.kt
@@ -1,5 +1,6 @@
 package com.paulinasadowska.rxworkmanagerobservers
 
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.WorkManager
 import androidx.work.WorkRequest
@@ -31,7 +32,7 @@ class WorkDatasObservableTest {
         private const val REQUEST_TAG = "requestTag"
     }
 
-    private val workManager by lazy { WorkManager.getInstance() }
+    private val workManager by lazy { WorkManager.getInstance(getApplicationContext()) }
 
     @Before
     fun setUp() {

--- a/rx-workmanager-observers/src/androidTest/java/com/paulinasadowska/rxworkmanagerobservers/WorkDatasObservableTest.kt
+++ b/rx-workmanager-observers/src/androidTest/java/com/paulinasadowska/rxworkmanagerobservers/WorkDatasObservableTest.kt
@@ -11,7 +11,7 @@ import com.paulinasadowska.rxworkmanagerobservers.utils.DEFAULT_DELAY_LONG
 import com.paulinasadowska.rxworkmanagerobservers.utils.createEchoRequest
 import com.paulinasadowska.rxworkmanagerobservers.utils.initializeTestWorkManager
 import com.paulinasadowska.rxworkmanagerobservers.workers.EchoWorker.Companion.KEY_ECHO_MESSAGE
-import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers
 import org.hamcrest.Matchers.emptyIterable

--- a/rx-workmanager-observers/src/androidTest/java/com/paulinasadowska/rxworkmanagerobservers/WorkInfoObservableTest.kt
+++ b/rx-workmanager-observers/src/androidTest/java/com/paulinasadowska/rxworkmanagerobservers/WorkInfoObservableTest.kt
@@ -1,10 +1,10 @@
 package com.paulinasadowska.rxworkmanagerobservers
 
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.*
 import com.paulinasadowska.rxworkmanagerobservers.exceptions.WorkFailedException
 import com.paulinasadowska.rxworkmanagerobservers.extensions.getWorkInfoByIdObservable
-import com.paulinasadowska.rxworkmanagerobservers.extensions.toWorkInfoObservable
 import com.paulinasadowska.rxworkmanagerobservers.utils.DEFAULT_DELAY
 import com.paulinasadowska.rxworkmanagerobservers.utils.createEchoRequest
 import com.paulinasadowska.rxworkmanagerobservers.utils.initializeTestWorkManager
@@ -23,7 +23,7 @@ class WorkInfoObservableTest {
         private const val EXAMPLE_ECHO_MESSAGE = "some message"
     }
 
-    private val workManager by lazy { WorkManager.getInstance() }
+    private val workManager by lazy { WorkManager.getInstance(getApplicationContext()) }
 
     @Before
     fun setUp() {

--- a/rx-workmanager-observers/src/androidTest/java/com/paulinasadowska/rxworkmanagerobservers/WorkInfoObservableTest.kt
+++ b/rx-workmanager-observers/src/androidTest/java/com/paulinasadowska/rxworkmanagerobservers/WorkInfoObservableTest.kt
@@ -9,7 +9,7 @@ import com.paulinasadowska.rxworkmanagerobservers.utils.DEFAULT_DELAY
 import com.paulinasadowska.rxworkmanagerobservers.utils.createEchoRequest
 import com.paulinasadowska.rxworkmanagerobservers.utils.initializeTestWorkManager
 import com.paulinasadowska.rxworkmanagerobservers.workers.EchoWorker.Companion.KEY_ECHO_MESSAGE
-import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import junit.framework.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test

--- a/rx-workmanager-observers/src/androidTest/java/com/paulinasadowska/rxworkmanagerobservers/utils/Constants.kt
+++ b/rx-workmanager-observers/src/androidTest/java/com/paulinasadowska/rxworkmanagerobservers/utils/Constants.kt
@@ -1,4 +1,4 @@
 package com.paulinasadowska.rxworkmanagerobservers.utils
 
-internal const val DEFAULT_DELAY = 30L
-internal const val DEFAULT_DELAY_LONG = 60L
+internal const val DEFAULT_DELAY = 50L
+internal const val DEFAULT_DELAY_LONG = 100L

--- a/rx-workmanager-observers/src/main/java/com/paulinasadowska/rxworkmanagerobservers/WorkDataSingle.kt
+++ b/rx-workmanager-observers/src/main/java/com/paulinasadowska/rxworkmanagerobservers/WorkDataSingle.kt
@@ -5,7 +5,7 @@ import androidx.work.Data
 import androidx.work.WorkInfo
 import com.paulinasadowska.rxworkmanagerobservers.base.MainThreadSingle
 import com.paulinasadowska.rxworkmanagerobservers.observers.WorkDataObserver
-import io.reactivex.SingleObserver
+import io.reactivex.rxjava3.core.SingleObserver
 
 class WorkDataSingle(
         private val liveData: LiveData<WorkInfo>

--- a/rx-workmanager-observers/src/main/java/com/paulinasadowska/rxworkmanagerobservers/WorkDatasObservable.kt
+++ b/rx-workmanager-observers/src/main/java/com/paulinasadowska/rxworkmanagerobservers/WorkDatasObservable.kt
@@ -5,7 +5,7 @@ import androidx.work.Data
 import androidx.work.WorkInfo
 import com.paulinasadowska.rxworkmanagerobservers.base.MainThreadObservable
 import com.paulinasadowska.rxworkmanagerobservers.observers.WorkDatasObserver
-import io.reactivex.Observer
+import io.reactivex.rxjava3.core.Observer
 
 class WorkDatasObservable(
         private val liveData: LiveData<List<WorkInfo>>,

--- a/rx-workmanager-observers/src/main/java/com/paulinasadowska/rxworkmanagerobservers/WorkInfoObservable.kt
+++ b/rx-workmanager-observers/src/main/java/com/paulinasadowska/rxworkmanagerobservers/WorkInfoObservable.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.work.WorkInfo
 import com.paulinasadowska.rxworkmanagerobservers.base.MainThreadObservable
 import com.paulinasadowska.rxworkmanagerobservers.observers.WorkInfoObserver
-import io.reactivex.Observer
+import io.reactivex.rxjava3.core.Observer
 
 class WorkInfoObservable(
         private val liveData: LiveData<WorkInfo>

--- a/rx-workmanager-observers/src/main/java/com/paulinasadowska/rxworkmanagerobservers/base/MainThreadObservable.kt
+++ b/rx-workmanager-observers/src/main/java/com/paulinasadowska/rxworkmanagerobservers/base/MainThreadObservable.kt
@@ -1,11 +1,11 @@
 package com.paulinasadowska.rxworkmanagerobservers.base
 
 import com.paulinasadowska.rxworkmanagerobservers.exceptions.LiveDataSubscribedOnWrongThreadException
-import io.reactivex.Observable
-import io.reactivex.Observer
-import io.reactivex.disposables.Disposables
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.Observer
+import io.reactivex.rxjava3.disposables.Disposable
 
-abstract class MainThreadObservable<T> : Observable<T>() {
+abstract class MainThreadObservable<T : Any> : Observable<T>() {
 
     override fun subscribeActual(observer: Observer<in T>) {
         if (isOnMainThread()) {
@@ -18,7 +18,7 @@ abstract class MainThreadObservable<T> : Observable<T>() {
     abstract fun onSubscribeOnMainThread(observer: Observer<in T>)
 
     private fun Observer<*>.subscribeAndCallWrongThreadError() {
-        onSubscribe(Disposables.empty())
+        onSubscribe(Disposable.empty())
         onError(LiveDataSubscribedOnWrongThreadException())
     }
 }

--- a/rx-workmanager-observers/src/main/java/com/paulinasadowska/rxworkmanagerobservers/base/MainThreadSingle.kt
+++ b/rx-workmanager-observers/src/main/java/com/paulinasadowska/rxworkmanagerobservers/base/MainThreadSingle.kt
@@ -1,11 +1,11 @@
 package com.paulinasadowska.rxworkmanagerobservers.base
 
 import com.paulinasadowska.rxworkmanagerobservers.exceptions.LiveDataSubscribedOnWrongThreadException
-import io.reactivex.Single
-import io.reactivex.SingleObserver
-import io.reactivex.disposables.Disposables
+import io.reactivex.rxjava3.core.Single
+import io.reactivex.rxjava3.core.SingleObserver
+import io.reactivex.rxjava3.disposables.Disposable
 
-abstract class MainThreadSingle<T> : Single<T>() {
+abstract class MainThreadSingle<T : Any> : Single<T>() {
 
     override fun subscribeActual(observer: SingleObserver<in T>) {
         if (isOnMainThread()) {
@@ -18,7 +18,7 @@ abstract class MainThreadSingle<T> : Single<T>() {
     abstract fun onSubscribeOnMainThread(observer: SingleObserver<in T>)
 
     private fun SingleObserver<*>.subscribeAndCallWrongThreadError() {
-        onSubscribe(Disposables.empty())
+        onSubscribe(Disposable.empty())
         onError(LiveDataSubscribedOnWrongThreadException())
     }
 }

--- a/rx-workmanager-observers/src/main/java/com/paulinasadowska/rxworkmanagerobservers/extensions/LiveDataExtensions.kt
+++ b/rx-workmanager-observers/src/main/java/com/paulinasadowska/rxworkmanagerobservers/extensions/LiveDataExtensions.kt
@@ -7,8 +7,8 @@ import androidx.work.WorkInfo
 import com.paulinasadowska.rxworkmanagerobservers.WorkDataSingle
 import com.paulinasadowska.rxworkmanagerobservers.WorkDatasObservable
 import com.paulinasadowska.rxworkmanagerobservers.WorkInfoObservable
-import io.reactivex.Observable
-import io.reactivex.Single
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.Single
 
 fun LiveData<WorkInfo>.toWorkDataSingle(): Single<Data> {
     return WorkDataSingle(this)

--- a/rx-workmanager-observers/src/main/java/com/paulinasadowska/rxworkmanagerobservers/observers/WorkDataObserver.kt
+++ b/rx-workmanager-observers/src/main/java/com/paulinasadowska/rxworkmanagerobservers/observers/WorkDataObserver.kt
@@ -6,7 +6,7 @@ import androidx.work.WorkInfo
 import com.paulinasadowska.rxworkmanagerobservers.exceptions.WorkCancelledException
 import com.paulinasadowska.rxworkmanagerobservers.exceptions.WorkFailedException
 import com.paulinasadowska.rxworkmanagerobservers.observers.base.WorkInfoLiveDataObserver
-import io.reactivex.SingleObserver
+import io.reactivex.rxjava3.core.SingleObserver
 
 internal class WorkDataObserver(
         private val observer: SingleObserver<in Data>,

--- a/rx-workmanager-observers/src/main/java/com/paulinasadowska/rxworkmanagerobservers/observers/WorkDatasObserver.kt
+++ b/rx-workmanager-observers/src/main/java/com/paulinasadowska/rxworkmanagerobservers/observers/WorkDatasObserver.kt
@@ -7,7 +7,7 @@ import com.paulinasadowska.rxworkmanagerobservers.exceptions.WorkCancelledExcept
 import com.paulinasadowska.rxworkmanagerobservers.exceptions.WorkException
 import com.paulinasadowska.rxworkmanagerobservers.exceptions.WorkFailedException
 import com.paulinasadowska.rxworkmanagerobservers.observers.base.WorkInfosLiveDataObserver
-import io.reactivex.Observer
+import io.reactivex.rxjava3.core.Observer
 import java.util.*
 
 internal class WorkDatasObserver(

--- a/rx-workmanager-observers/src/main/java/com/paulinasadowska/rxworkmanagerobservers/observers/WorkInfoObserver.kt
+++ b/rx-workmanager-observers/src/main/java/com/paulinasadowska/rxworkmanagerobservers/observers/WorkInfoObserver.kt
@@ -5,7 +5,7 @@ import androidx.work.WorkInfo
 import com.paulinasadowska.rxworkmanagerobservers.exceptions.WorkException
 import com.paulinasadowska.rxworkmanagerobservers.exceptions.WorkFailedException
 import com.paulinasadowska.rxworkmanagerobservers.observers.base.WorkInfoLiveDataObserver
-import io.reactivex.Observer
+import io.reactivex.rxjava3.core.Observer
 
 internal class WorkInfoObserver(
         private val observer: Observer<in WorkInfo>,

--- a/rx-workmanager-observers/src/main/java/com/paulinasadowska/rxworkmanagerobservers/observers/base/LiveDataObserver.kt
+++ b/rx-workmanager-observers/src/main/java/com/paulinasadowska/rxworkmanagerobservers/observers/base/LiveDataObserver.kt
@@ -2,7 +2,7 @@ package com.paulinasadowska.rxworkmanagerobservers.observers.base
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
-import io.reactivex.android.MainThreadDisposable
+import io.reactivex.rxjava3.android.MainThreadDisposable
 
 internal abstract class LiveDataObserver<T>(
         private val liveData: LiveData<T>


### PR DESCRIPTION
- Migrate to RxJava 3 (3.1.3)
- Update 
  - RxAndroid to 3.0.0
  - AndroidX to 1.1.0
  - WorkManager to 2.5.0
- Set compile/target SDK to 30
- Fix jitpack publishing